### PR TITLE
fix: rulecheck validation to allow 'direct' and 'none' failover proxies

### DIFF
--- a/config.go
+++ b/config.go
@@ -246,11 +246,9 @@ func (c *Config) check() (err error) {
 			return stacktrace.NewError("rule %d: must contain 'proxy' or 'dns'", i)
 		}
 		if rule.Proxy != nil {
-			if *rule.Proxy != ProxyDirect.Name() && *rule.Proxy != ProxyNone.Name() {
-				for _, p := range rule.allProxiesName() {
-					if c.conf.Proxies[p] == nil {
-						return stacktrace.NewError("rule %d: '%s' must exist in 'proxies', or be 'direct' or 'none'", i, p)
-					}
+			for _, p := range rule.allProxiesName() {
+				if p != ProxyDirect.Name() && p != ProxyNone.Name() && c.conf.Proxies[p] == nil {
+					return stacktrace.NewError("rule %d: '%s' must exist in 'proxies', or be 'direct' or 'none'", i, p)
 				}
 			}
 		}
@@ -281,11 +279,9 @@ func (c *Config) check() (err error) {
 			return stacktrace.NewError("socks rule %d: must contain 'proxy' or 'dns'", i)
 		}
 		if rule.Proxy != nil {
-			if *rule.Proxy != ProxyDirect.Name() && *rule.Proxy != ProxyNone.Name() {
-				for _, p := range rule.allProxiesName() {
-					if c.conf.Proxies[p] == nil {
-						return stacktrace.NewError("socks rule %d: '%s' must exist in 'proxies', or be 'direct' or 'none'", i, p)
-					}
+			for _, p := range rule.allProxiesName() {
+				if p != ProxyDirect.Name() && p != ProxyNone.Name() && c.conf.Proxies[p] == nil {
+					return stacktrace.NewError("socks rule %d: '%s' must exist in 'proxies', or be 'direct' or 'none'", i, p)
 				}
 			}
 		}


### PR DESCRIPTION
# Description 
This PR fixes a validation bug in the rule checking logic which I believe is incorrectly rejecting the built-in 'direct' and 'none' proxy types when used in failover configurations.

# Message

Hello :) 

Nice repo.

I had a bit of a play with kpx as a potential solution to the 'occasional proxy' - corporate proxy required in office, no proxy in other environments. 

When I was attempted to failover to direct, received a rule check exception. Suggested fix in PR. My first use at Go, I may have missed something.

Cheers,
Alex