### PR TITLE
fix(pac): revert broken dnsDomainIs

### DIFF
--- a/pac.go
+++ b/pac.go
@@ -83,7 +83,7 @@ func isPlainHostName(host string) bool {
 	return !strings.Contains(host, ".")
 }
 func dnsDomainIs(host, domain string) bool {
-	return host == domain || strings.HasSuffix(host, "."+domain)
+	return strings.HasPrefix(domain, ".") && strings.HasSuffix(host, domain)
 }
 func localHostOrDomainIs(host, hostdom string) bool {
 	return host == hostdom || (!strings.Contains(host, ".") && strings.HasPrefix(hostdom, host+"."))


### PR DESCRIPTION
The current implementation will take a condition like `dnsDomainIs(host, ".domain.example.com")` and check if `host` ends in `..domain.example.com`.

The previous implementation had no issues, no need to change it.

Introduced-In:
10d1955dea817454dff99644c4157bb98caa5d01